### PR TITLE
ActiveResource version comparison is broken for 2.3.10

### DIFF
--- a/lib/chargify_api_ares.rb
+++ b/lib/chargify_api_ares.rb
@@ -20,7 +20,7 @@ module Chargify
   MIN_VERSION = '2.3.4'
 end
 require 'active_resource/version'
-unless ActiveResource::VERSION::STRING >= Chargify::MIN_VERSION
+unless Gem::Version.new(ActiveResource::VERSION::STRING) >= Gem::Version.new(Chargify::MIN_VERSION)
   abort <<-ERROR
     ActiveResource version #{Chargify::MIN_VERSION} or greater is required.
   ERROR


### PR DESCRIPTION
'2.3.10' >= '2.3.4' returns false when doing a string comparison, so this commit wraps both the version strings with Gem::Version.new so that the comparison is accurate. 
