### PR TITLE
Fix compatibility with Rails 3.1

### DIFF
--- a/lib/chargify_api_ares.rb
+++ b/lib/chargify_api_ares.rb
@@ -69,6 +69,8 @@ module Chargify
   end
   
   class Base < ActiveResource::Base
+    self.format = :xml
+  
     def self.element_name
       name.split(/::/).last.underscore
     end


### PR DESCRIPTION
We had an issues with the gem after upgrading to Rails 3.1. This fix solved it for us.
