### PR TITLE
NIL check for missing payment profile for subscriptions

### DIFF
--- a/lib/chargify_api_ares.rb
+++ b/lib/chargify_api_ares.rb
@@ -131,7 +131,7 @@ module Chargify
     end
 
     def payment_profile
-      credit_card
+      self.respond_to?('credit_card') ? credit_card : nil
     end
 
     # Perform a one-time charge on an existing subscription.


### PR DESCRIPTION
I was trying to access the payment_profile of a subscription that did not have
one. When doing so an Undefined method "credit_card" exception was being thrown.
I added a check to the payment_profile method to check and see if the instance
responds to credit_card before attempting to return it.
