### PR TITLE
rails-3.1 issues fixed properly now

### DIFF
--- a/lib/chargify_api_ares.rb
+++ b/lib/chargify_api_ares.rb
@@ -58,7 +58,7 @@ module Chargify
       Base.user      = api_key
       Base.password  = 'X'
       Base.format    = format unless format.blank?
-      Base.timeout   = timeout unless (timeout.blank?)
+      Base.timeout   = timeout unless timeout.blank?
 
       # The Chargify API expects the resources' attributes to be top-level.
       Base.include_root_in_json = false


### PR DESCRIPTION
Hi guys,

I tracked down the cause of the rails-3.1 issues.

They were worked around by e1e016e, which set the default format to XML — but JSON requests were still broken.

The issue is that as of rails-3.1, JSON request params are wrapped in the resource name, instead of being top-level like the Chargify API expects:

```
{'subscription': {...}}
```

The fix is to disable that behaviour on Chargify::Base — done in benhoskings@6bb5cc2.
