### PR TITLE
Please honor subsequent changes to configuration

### DIFF
--- a/lib/chargify_api_ares.rb
+++ b/lib/chargify_api_ares.rb
@@ -61,7 +61,7 @@ module Chargify
       Base.password  = 'X'
       Base.timeout   = timeout unless (timeout.blank?)
 
-      self.site ||= "https://#{subdomain}.chargify.com"
+      self.site = "https://#{subdomain}.chargify.com"
 
       Base.site                       = site
       Subscription::Component.site    = site + "/subscriptions/:subscription_id"

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -6,5 +6,25 @@ describe Chargify::Base do
     Chargify::Base.stub!(:name).and_return("Test::Namespace::ElementName")
     Chargify::Base.element_name.should eql('element_name')
   end
-  
+
+  context 'configuration changes' do
+    before do
+      @original_subdomain = Chargify.subdomain
+    end
+
+    it "honors changes made after the first configuration" do
+      expect do
+        Chargify.configure do |c|
+          c.subdomain = "something-new"
+        end
+      end.to change { Chargify::Base.site.to_s }.to("https://something-new.chargify.com")
+    end
+    
+    after do
+      Chargify.configure do |c|
+        c.subdomain = @original_subdomain
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Allows anyone using this gem to change the configuration within a script, for example:

```
def clone_site(old_subdomain, new_subdomain)
  Chargify.configure do |c|
    c.subdomain = old_subdomain
  end

  products_to_migrate = Chargify::Product.all # old site

  Chargify.configure do |c|
    c.subdomain = new_subdomain
  end

  do_the_clone! # uses the new site
end
```
