### PR TITLE
Easy delete of coupons from subscriptions

### DIFF
--- a/lib/chargify_api_ares.rb
+++ b/lib/chargify_api_ares.rb
@@ -193,8 +193,12 @@ module Chargify
       post :add_coupon, :code => code
     end
 
-    def remove_coupon(code)
-      delete :remove_coupon, :code => code
+    def remove_coupon(code=nil)
+      if code.nil?
+        delete :remove_coupon
+      else
+        delete :remove_coupon, :code => code
+      end
     end
 
     class Component < Base


### PR DESCRIPTION
Hey guys, here is a change to the gem that allows you to delete a coupon off of a subscription w/o knowing its id.
