### PR TITLE
Minor edit to coupon example to correct an error.

### DIFF
--- a/examples/coupons.rb
+++ b/examples/coupons.rb
@@ -22,7 +22,7 @@ coupon = Chargify::Coupon.create(
 )
 
 # Lookup up existing coupon using the product_family_id and the coupon code
-coupon = Chargify::Subscription::Coupon.find_by_product_family_id_and_code(2,"10OFF")
+coupon = Chargify::Coupon.find_by_product_family_id_and_code(2,"10OFF")
 
 # Looking up all coupons for a product family
 coupons = Chargify::Coupon.find_all_by_product_family_id(12345)


### PR DESCRIPTION
I was having trouble getting this to work:

```
coupon = Chargify::Subscription::Coupon.find_by_product_family_id_and_code(2,"10OFF")
```

as it's shown in the coupon example on line 25.

I noticed all the other examples use this syntax instead: 

```
coupon = Chargify::Coupon.find_by_product_family_id_and_code(2,"10OFF")
```

which works perfect.

I'm not sure if this is just an issue with me using it wrong, but it seems like a minor error.
