### PR TITLE
Force PF::Component#create to use correct path

### DIFF
--- a/lib/chargify_api_ares/resources/product_family.rb
+++ b/lib/chargify_api_ares/resources/product_family.rb
@@ -10,6 +10,34 @@ module Chargify
     
     class Component < Base
       self.prefix = "/product_families/:product_family_id/"
+
+      def self.create_path(prefix_options = {}, query_options = nil)
+        check_prefix_options(prefix_options)
+        prefix_options, query_options = split_options(prefix_options) if query_options.nil?
+        "#{prefix(prefix_options)}:component_kind_plural.#{format.extension}#{query_string(query_options)}"
+      end
+
+      def create_path(options = nil)
+        path = self.class.create_path(options || prefix_options)
+        path.gsub(/:component_kind_plural/, component_kind_plural)
+      end
+
+      # Create uses a different path other than the collection_path.  It is expected to POST to
+      # /product_families/:product_family_id/:plural_kind.xml
+      def create
+        connection.post(create_path, encode(:root => component_kind, :except => [:kind]), self.class.headers).tap do |response|
+          self.id = id_from_response(response)
+          load_attributes_from_response(response)
+        end
+      end
+
+      def component_kind
+        @attributes['kind']
+      end
+
+      def component_kind_plural
+        "#{self.component_kind}s"
+      end
     end
     
     class Coupon < Base

--- a/spec/resources/product_family_component_spec.rb
+++ b/spec/resources/product_family_component_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe Chargify::ProductFamily::Component do
+  context 'create' do
+    let(:component) { Chargify::ProductFamily::Component }
+    let(:connection) { double('connection').as_null_object }
+    let(:response) { double('response').as_null_object }
+
+    before :each do
+      component.any_instance.stub(:connection).and_return(connection)
+      response.stub(:tap)
+    end
+
+    it 'should post to the correct url' do
+      connection.should_receive(:post) do |path, body, headers|
+        path.should == '/product_families/123/quantity_based_components.xml'
+
+        response
+      end
+
+      component.create(:product_family_id => 123, :kind => 'quantity_based_component', :name => 'Foo Component')
+    end
+
+    it 'should not include the kind attribute in the post' do
+      connection.should_receive(:post) do |path, body, headers|
+        body.should_not match(/kind/)
+
+        response
+      end
+
+      component.create(:product_family_id => 123, :kind => 'quantity_based_component', :name => 'Foo Component')
+    end
+
+    it 'should have the component kind as the root' do
+      connection.should_receive(:post) do |path, body, headers|
+        #The second line in the xml should be the root.  This saves us from using nokogiri for this one example.
+        body.split($/)[1].should match(/quantity_based_component/)
+
+        response
+      end
+
+      component.create(:product_family_id => 123, :kind => 'quantity_based_component', :name => 'Foo Component')
+    end
+  end
+end


### PR DESCRIPTION
This fixes the creation of components via the API.

Please note that these tests require the changes made in #49.
