### PR TITLE
Proof of concept example for multiple allocations JSON-only API.

### DIFF
--- a/lib/chargify_api_ares.rb
+++ b/lib/chargify_api_ares.rb
@@ -1,6 +1,7 @@
 require 'active_resource'
 require 'chargify_api_ares/config'
 require 'chargify_api_ares/resources/base'
+require 'chargify_api_ares/resources/allocation'
 require 'chargify_api_ares/resources/charge'
 require 'chargify_api_ares/resources/component'
 require 'chargify_api_ares/resources/coupon'

--- a/lib/chargify_api_ares/resources/allocation.rb
+++ b/lib/chargify_api_ares/resources/allocation.rb
@@ -1,0 +1,22 @@
+module Chargify
+  class Allocation < Base
+    self.prefix = '/subscriptions/:subscription_id/'
+    self.format = :json
+
+    # Chargify allocations returns a non-restful response
+    # so we need to override the load_attributes_from_response method from
+    # ActiveRecord in order to interpret Chargify's custom response.
+    def load_attributes_from_response(response)
+      if (response_code_allows_body?(response.code) &&
+          (response['Content-Length'].nil? || response['Content-Length'] != "0") &&
+          !response.body.nil? && response.body.strip.size > 0)
+
+        allocations = []
+        self.class.format.decode(response.body).each do |a|
+          allocations << load(a, true, true)
+        end
+        @persisted = true
+      end
+    end
+  end
+end

--- a/lib/chargify_api_ares/resources/subscription.rb
+++ b/lib/chargify_api_ares/resources/subscription.rb
@@ -17,6 +17,20 @@ module Chargify
       destroy
     end
 
+
+    def allocate_components(components, params={})
+      allocations = []
+      components.each do |c|
+        allocations << {
+                         :component_id => c.component_id,
+                         :quantity => c.allocated_quantity
+                       }
+      end
+
+      params.merge!({:subscription_id => self.id, :allocations => allocations})
+      Allocation.create(params)
+    end
+
     def component(id)
       Component.find(id, :params => {:subscription_id => self.id})
     end
@@ -25,7 +39,7 @@ module Chargify
       params.merge!({:subscription_id => self.id})
       Component.find(:all, :params => params)
     end
-    
+
     def events(params = {})
       params.merge!(:subscription_id => self.id)
       Event.all(:params => params)
@@ -106,7 +120,7 @@ module Chargify
     class Event < Base
       self.prefix = '/subscriptions/:subscription_id/'
     end
-    
+
     class Statement < Base
       self.prefix = "/subscriptions/:subscription_id/"
     end


### PR DESCRIPTION
This is in no way ready for merge but it's an example of how to integrate Chargify's allocations api with ActiveResource .. sort of.

Usage example:

``` ruby
# Set all components to 100 allocations
s = Chargify::Subscription.find xyz
components = s.components
components.each do |c|
components.allocated_quantity = 100
end
s.allocate_components components
```

It receives an array of Component objects and does the submission to Chargify to update those components. Works perfectly except for the response. In this case ActiveRecord expect's the POST response (which is in REST terminology a CREATE action) to return attributes for _one_ resource not an _array_ of resources, so ActiveRecord freaks out when it receives an array of allocations from Chargify.

I overloaded the method ActiveRecord uses to read the response after `create` to interpret Chargify's response, but it's a pretty ugly as heck hack.

Anyways, food for thought, any ideas how to get around the non-RESTful nature of this API is more than welcome.
