### PR TITLE
Fixed broken Chargify.site

### DIFF
--- a/lib/chargify_api_ares/config.rb
+++ b/lib/chargify_api_ares/config.rb
@@ -8,10 +8,11 @@ module Chargify
       self.domain    = domain    || "chargify.com"
       self.format    = format    || :xml
       self.subdomain = subdomain || "test"
+      self.site      = site || "#{protocol}://#{subdomain}.#{domain}"
+      Base.site      = site
       Base.user      = api_key
       Base.password  = 'X'
       Base.timeout   = timeout unless (timeout.blank?)
-      Base.site      = site || "#{protocol}://#{subdomain}.#{domain}"
       Base.format    = format
     end
   end


### PR DESCRIPTION
![](http://media3.giphy.com/media/sLyeURTOizFXa/200.gif)

We were running the version `0.5.0` and we recently updated to the latest and we found out that recently `Chargify.site` was broken. The bug was introduced on https://github.com/chargify/chargify_api_ares/pull/62 while refactoring the configuration. We rely on that attribute to generate links to update payments.
