### PR TITLE
missing require for invoice model

### DIFF
--- a/lib/chargify_api_ares.rb
+++ b/lib/chargify_api_ares.rb
@@ -17,6 +17,7 @@ require 'chargify_api_ares/resources/subscription'
 require 'chargify_api_ares/resources/transaction'
 require 'chargify_api_ares/resources/usage'
 require 'chargify_api_ares/resources/webhook'
+require 'chargify_api_ares/resources/invoice'
 
 require 'active_resource/version'
 if defined?(::ActiveResource::VERSION::MAJOR) &&


### PR DESCRIPTION
forgot to add the require for invoice model contributed a few days ago, when updating the gem and deleting the model it went missing because of the lack of require.

sry :/
