### PR TITLE
Remove 'bank_account' attribute from subscription upon save

### DIFF
--- a/lib/chargify_api_ares/resources/subscription.rb
+++ b/lib/chargify_api_ares/resources/subscription.rb
@@ -12,6 +12,7 @@ module Chargify
       self.attributes.delete('customer')
       self.attributes.delete('product')
       self.attributes.delete('credit_card')
+      self.attributes.delete('bank_account')
       super
     end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -46,6 +46,7 @@ FactoryGirl.define do
     f.customer Chargify::Customer.new
     f.product Chargify::Product.new
     f.credit_card "CREDIT CARD"
+    f.bank_account "BANK ACCOUNT"
   end
 
   factory :component, :class => Chargify::Component do |f|

--- a/spec/resources/subscription_spec.rb
+++ b/spec/resources/subscription_spec.rb
@@ -24,6 +24,12 @@ describe Chargify::Subscription, :fake_resource do
       @subscription.save!
       @subscription.attributes['credit_card'].should be_blank
     end
+
+    it 'strips bank account' do
+      @subscription.attributes['bank_account'].should_not be_blank
+      @subscription.save!
+      @subscription.attributes['bank_account'].should be_blank
+    end
     
     it "doesn't strip other attrs" do
       subscription = build(:subscription)


### PR DESCRIPTION
Applicable to accounts that support the new ACH payment profile.
