### PR TITLE
Ignore .ruby-[version|gemset]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
 config/remote.yml
 spec/remote/remote.yml
 pkg
-.rvmrc
 .ruby-version
+.ruby-gemset
 .bundle/
 bin/
-.rbenv-version
 tmp


### PR DESCRIPTION
All ruby version managers support .ruby-version and rvm supports
.ruby-gemset.  That should cover all the bases.
