### PR TITLE
Add missing Subscription::Transaction::Taxation

### DIFF
--- a/lib/chargify_api_ares/resources/subscription.rb
+++ b/lib/chargify_api_ares/resources/subscription.rb
@@ -168,6 +168,11 @@ module Chargify
         attrs.merge!(:payment_id => self.id)
         Subscription.find(self.prefix_options[:subscription_id]).refund(attrs)
       end
+
+      class Taxation < Base
+        class TaxRule < Base
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
We just started getting the following error:
`ArgumentError: undefined class/module Chargify::Subscription::Transaction::Taxation`

I've added the missing `Taxation` class along with the nested `TaxRule` class found in the `Chargify::Transaction::Taxation` namespace.
