### PR TITLE
Duplicate prevention for one time charges

### DIFF
--- a/lib/chargify_api_ares/resources/charge.rb
+++ b/lib/chargify_api_ares/resources/charge.rb
@@ -1,5 +1,7 @@
 module Chargify
   class Charge < Base
+    include ResponseHelper
+
     self.prefix = '/subscriptions/:subscription_id/'
   end
 end

--- a/spec/remote/remote_spec.rb
+++ b/spec/remote/remote_spec.rb
@@ -289,6 +289,20 @@ describe "Remote" do
       }.should change{@subscription.reload.transactions.size}.by(2)
       most_recent_transaction(@subscription).amount_in_cents.should == 700
     end
+
+    context "duplicate protection" do
+      it "creates with duplicate protection" do
+        uniqueness_token = SecureRandom.hex
+
+        expect {
+          @subscription.charge(:amount => 5, :memo => 'One Time Charge With Duplicate Protection', :uniqueness_token => uniqueness_token)
+        }.to_not raise_error
+
+        expect {
+          @subscription.charge(:amount => 5, :memo => 'One Time Charge With Duplicate Protection', :uniqueness_token => uniqueness_token)
+        }.to raise_error ActiveResource::ResourceConflict
+      end
+    end
   end
 
   describe "failing to add a one time charge" do

--- a/spec/remote/remote_spec.rb
+++ b/spec/remote/remote_spec.rb
@@ -290,8 +290,8 @@ describe "Remote" do
       most_recent_transaction(@subscription).amount_in_cents.should == 700
     end
 
-    context "duplicate protection" do
-      it "creates with duplicate protection" do
+    context "with duplicate protection" do
+      it "creates the charge and payment and detects duplicates" do
         uniqueness_token = SecureRandom.hex
 
         expect {


### PR DESCRIPTION
The [PR](https://github.com/chargify/chargify_api_ares/pull/109) that introduced support for duplicate prevention didn't add it for one time charges. This is what was missing.