### PR TITLE
[internal] Re-organizing remote specs

### DIFF
--- a/spec/remote/remote_spec.rb
+++ b/spec/remote/remote_spec.rb
@@ -85,6 +85,14 @@ describe "Remote" do
 
   let(:johnadoes_credit_card) { Chargify::PaymentProfile.create(good_payment_profile_attributes.merge(:customer_id => johnadoe.id)) }
 
+  let(:subscription_to_pro) do
+    Chargify::Subscription.create(
+      :product_handle => pro_plan.handle,
+      :customer_reference => johnadoe.reference,
+      :payment_profile_attributes => good_payment_profile_attributes
+    )
+  end
+
   before(:all) do
     # Make sure the test site data is set up correctly
     clear_site_data; acme_projects; basic_plan; pro_plan; johnadoe; johnadoes_credit_card
@@ -98,10 +106,10 @@ describe "Remote" do
           :uniqueness_token => uniqueness_token,
           :product_handle => basic_plan.handle,
           :customer_attributes => {
-            :first_name => "Lil",
-            :last_name => "Wayne",
-            :email => "lil.wayne@example.com",
-            :reference => "lilwayne"
+            :first_name => "Jane",
+            :last_name => "Doe",
+            :email => "jane.doe@example.com",
+            :reference => "janedoe"
           },
           :payment_profile_attributes => good_payment_profile_attributes)
       }.to_not raise_error
@@ -111,10 +119,10 @@ describe "Remote" do
           :uniqueness_token => uniqueness_token,
           :product_handle => basic_plan.handle,
           :customer_attributes => {
-            :first_name => "Lil",
-            :last_name => "Wayne",
-            :email => "lil.wayne@example.com",
-            :reference => "lilwayne"
+            :first_name => "Jane",
+            :last_name => "Doe",
+            :email => "jane.doe@example.com",
+            :reference => "janedoe"
           },
           :payment_profile_attributes => good_payment_profile_attributes)
       }.to raise_error ActiveResource::ResourceConflict
@@ -595,7 +603,7 @@ describe "Remote" do
 
     it 'responds with errors when request is invalid' do
       response = @subscription.credit(:amount => nil)
-      expect(response.errors.full_messages.first).to eql "Amount in cents: is not a number."
+      expect(response.errors.full_messages.first).to eql "Amount: is not a number."
     end
   end
 
@@ -739,6 +747,32 @@ describe "Remote" do
 
       it 'should lits all events for a subscription' do
         @subscription.events.to_a.should_not be_empty
+      end
+    end
+  end
+
+  context "metadata" do
+    before { subscription_to_pro }
+    let(:subscription) { Chargify::Subscription.last }
+
+    describe 'listing metadata for a subscription' do
+      it 'returns a list of metadata' do
+        list = subscription.metadata
+        expect(list).to eql([])
+      end
+    end
+
+    describe 'creating a piece of metadata' do
+      it 'can create a new metadata' do
+        data = subscription.create_metadata(:name => 'favorite color', :value => 'red')
+
+        expect(data).to be_persisted
+        expect(data.name).to eql('favorite color')
+        expect(data.value).to eql('red')
+
+        list = subscription.metadata
+        expect(list.size).to eql(1)
+        expect(list).to include(data)
       end
     end
   end

--- a/spec/resources/base_spec.rb
+++ b/spec/resources/base_spec.rb
@@ -38,13 +38,13 @@ describe Chargify::Base do
         c.subdomain = "first"
       end
 
-      expect(Chargify::Base.site.to_s).to eql("http://first.chargify.dev")
+      expect(Chargify::Base.site.to_s).to eql("https://first.chargify.com")
 
       expect do
         Chargify.configure do |c|
           c.subdomain = "second"
         end
-      end.to change { Chargify::Base.site.to_s }.to("http://second.chargify.dev")
+      end.to change { Chargify::Base.site.to_s }.to("https://second.chargify.com")
 
     end
 

--- a/spec/resources/subscription_metadata_spec.rb
+++ b/spec/resources/subscription_metadata_spec.rb
@@ -10,45 +10,4 @@ describe Chargify::SubscriptionMetadata do
     its(:inspect) { should eql("#<Chargify::SubscriptionMetadata resource_id: nil, current_name: nil, name: nil, value: nil>") }
   end
 
-  describe 'listing metadata for a subscription', :remote => true do
-    it 'returns a list of metadata' do
-      subscription, list = nil
-
-      VCR.use_cassette 'subscription/find' do
-        subscription = Chargify::Subscription.last
-      end
-
-      VCR.use_cassette 'subscription_metadata/list' do
-        list = subscription.metadata
-      end
-
-      expect(list).to eql([])
-    end
-  end
-
-  describe 'creating a piece of metadata', :remote => true do
-    it 'can create a new metadata' do
-      subscription, data, list = nil
-
-      VCR.use_cassette 'subscription/find' do
-        subscription = Chargify::Subscription.last
-      end
-
-      VCR.use_cassette 'subscription_metadata/create' do
-        # Shorthand for Chargify::SubscriptionMetadata.create(:resource_id => sub.id ...)
-        data = subscription.create_metadata(:name => 'favorite color', :value => 'red')
-      end
-
-      expect(data).to be_persisted
-      expect(data.name).to eql('favorite color')
-      expect(data.value).to eql('red')
-
-      VCR.use_cassette 'subscription_metadata/list-after-create' do
-        list = subscription.metadata
-      end
-
-      expect(list.size).to eql(1)
-      expect(list).to include(data)
-    end
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,13 +13,6 @@ FactoryGirl.find_definitions
 ActiveResource::Base.send :include, ActiveResource::FakeResource
 FakeWeb.allow_net_connect = false
 
-Chargify.configure do |c|
-  c.subdomain = ENV['SUBDOMAIN'] || 'acme'
-  c.api_key   = ENV['API_KEY']   || 'acme_test_key'
-  c.domain    = ENV['DOMAIN']    || 'chargify.dev'
-  c.protocol  = ENV['protocol']  || 'http'
-end
-
 VCR.configure do |c|
   c.allow_http_connections_when_no_cassette = true
   c.cassette_library_dir = 'spec/cassettes'


### PR DESCRIPTION
This moves `remote: true` specs into the `spec/remote` directory to make it easier to have all remote specs run in one place. It also takes advantage of the existing setup/teardown of remote specs so that no data needs to be assumed to be in place. VCR is no longer needed for these specs.

Also removing Lil Wayne from the dummy data since he hasn't had a decent album since 2008.