### PR TITLE
Set authors to 'Chargify Development Team', add contributors list

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ following. Please note that this step is required.
 
 Now you'll have access to classes the interact with the Chargify API, such as:
 
-* `Chargify::Product`  
-* `Chargify::Customer`  
+* `Chargify::Product`
+* `Chargify::Customer`
 * `Chargify::Subscription`
 
 It allows you to interface with the Chargify API using simple ActiveRecord-like syntax, i.e.:
@@ -197,3 +197,7 @@ sure someone already hasn't requested it and/or contributed it
 fine, but please isolate it to its own commit so we can cherry-pick
 around it.
 
+### Contributors
+
+We would like to publicly thank [everyone who has contributed](https://github.com/chargify/chargify_api_ares/graphs/contributors) their time
+and talents to developing this gem. Thank you!

--- a/chargify_api_ares.gemspec
+++ b/chargify_api_ares.gemspec
@@ -1,16 +1,16 @@
 Gem::Specification.new do |s|
   s.specification_version = 3 if s.respond_to? :specification_version=
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.rubygems_version = '1.3.7'
+  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version= 
+  s.rubygems_version          = '1.3.7'
 
-  s.name    = 'chargify_api_ares'
-  s.version = '1.3.4'
-  s.date    = '2015-05-14'
-  s.summary = 'A Chargify API wrapper for Ruby using ActiveResource'
+  s.name        = 'chargify_api_ares'
+  s.version     = '1.3.4'
+  s.date        = '2015-05-14'
+  s.summary     = 'A Chargify API wrapper for Ruby using ActiveResource'
   s.description = ''
-  s.authors = ["Michael Klett", "Nathan Verni", "Eric Farkas", "Wendy Smoak"]
-  s.email = 'support@chargify.com'
-  s.homepage = 'http://github.com/chargify/chargify_api_ares'
+  s.authors     = ["Chargify Development Team"]
+  s.email       = 'dev@chargify.com'
+  s.homepage    = 'http://github.com/chargify/chargify_api_ares'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/gemfiles/rails_3.gemfile.lock
+++ b/gemfiles/rails_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    chargify_api_ares (1.3.3)
+    chargify_api_ares (1.3.4)
       activeresource (>= 3.2.16)
 
 GEM

--- a/gemfiles/rails_4.1.gemfile.lock
+++ b/gemfiles/rails_4.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    chargify_api_ares (1.3.3)
+    chargify_api_ares (1.3.4)
       activeresource (>= 3.2.16)
 
 GEM

--- a/gemfiles/rails_4.gemfile.lock
+++ b/gemfiles/rails_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    chargify_api_ares (1.3.3)
+    chargify_api_ares (1.3.4)
       activeresource (>= 3.2.16)
 
 GEM


### PR DESCRIPTION
Changes the gem's authors to a more generic "Chargify Development Team".

In an attempt to acknowledge the contributions of everyone outside the current Chargify dev team, and thank them for such contribution, also adds a "Contributors" section to the README.