### PR TITLE
Reverted custom load_remote_errors

### DIFF
--- a/lib/chargify_api_ares/resources/migration.rb
+++ b/lib/chargify_api_ares/resources/migration.rb
@@ -12,19 +12,6 @@ module Chargify
 
     private
 
-    # Chargify returns a non-standard XML error response for Migration.  Since the API wants to maintain
-    # backwards compatibility, we will work around that when we parse errors here by overriding the
-    # framework's `load_remote_errors` with our own for just XML
-    def load_remote_errors(remote_errors, save_cache = false)
-      case self.class.format
-      when ActiveResource::Formats[:xml]
-        array = [Hash.from_xml(remote_errors.response.body)["errors"]] rescue []
-        errors.from_array array, save_cache
-      else
-        super
-      end
-    end
-
     class Preview < Base
       self.prefix = "/subscriptions/:subscription_id/migrations/"
 


### PR DESCRIPTION
Chargify changed the XML response and now it conforms to ActiveResource API, Fix chargify/chargify_api_ares#117