### PR TITLE
Bulk allocations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
+before_install:
+  - gem update --system
+  - gem update bundler
 rvm:
   - 2.1.3
   - 2.0.0

--- a/lib/chargify_api_ares/resources/allocation.rb
+++ b/lib/chargify_api_ares/resources/allocation.rb
@@ -1,9 +1,26 @@
 module Chargify
-  
   class Allocation < Base
-    
-    self.prefix = "/subscriptions/:subscription_id/components/:component_id/" 
-    
+    self.prefix = "/subscriptions/:subscription_id/components/:component_id/"
+
+    def self.bulk_create_prefix(opts = {})
+      subscription_id = opts[:subscription_id]
+      raise ArgumentError, 'subscription_id required' if subscription_id.nil?
+
+      "/subscriptions/#{subscription_id}/allocations.#{format.extension}"
+    end
+
+    def self.bulk_create(opts = {})
+      return [] if opts[:allocations].blank?
+
+      subscription_id = opts.delete(:subscription_id)
+      raise ArgumentError, 'subscription_id required' if subscription_id.nil?
+
+      response = connection.post(
+        bulk_create_prefix(subscription_id: subscription_id),
+        format.encode(opts),
+        headers
+      )
+      instantiate_collection(format.decode(response.body))
+    end
   end
-  
 end

--- a/spec/resources/allocation_spec.rb
+++ b/spec/resources/allocation_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+describe Chargify::Allocation do
+  let(:subscription_id) { 123 }
+  let(:component_id) { 456 }
+  let(:allocations) do
+    [
+      {
+        component_id: component_id,
+        quantity: 1,
+        memo: 'test'
+      }
+    ]
+  end
+  describe '.bulk_create' do
+    context 'when no allocations are specified' do
+      it 'returns an empty array' do
+        result = Chargify::Allocation.bulk_create(allocations: [])
+        expect(result).to be_empty
+      end
+    end
+
+    context 'when the subscription_id is missing' do
+      it 'raises' do
+        expect {
+          Chargify::Allocation.bulk_create(allocations: allocations)
+        }.to raise_error(/subscription_id required/)
+      end
+    end
+
+    context 'with correct parameters' do
+      let(:json_body) do
+        [{
+          allocation: {
+            component_id: component_id,
+            subscription_id: subscription_id,
+            quantity: 1,
+            previous_quantity: 0,
+            memo: 'test',
+            timestamp: Time.now.to_s(:iso8601),
+            proration_upgrade_scheme: 'prorate-attempt-capture',
+            proration_downgrade_scheme: 'no-prorate',
+            payment: {
+              amount_in_cents: 2000,
+              success: true,
+              memo: 'Payment for: Prorated component allocation',
+              id: 123
+            }
+          }
+        }].to_json
+      end
+
+      let(:headers) do
+        {
+          'Content-Type' => 'application/json',
+          'Authorization' => 'Basic foobar=='
+        }
+      end
+
+      before do
+        FakeWeb.clean_registry
+        Chargify::Allocation.format = :json
+        FakeWeb.register_uri(
+          :post,
+          URI.join(
+            test_domain,
+            Chargify::Allocation.bulk_create_prefix(
+              subscription_id: subscription_id
+            )
+          ),
+          body: json_body,
+          content_type: 'application/json'
+        )
+      end
+
+      after do
+        FakeWeb.clean_registry
+      end
+
+      it 'returns a collection of allocations' do
+        result = Chargify::Allocation.bulk_create(
+          subscription_id: subscription_id,
+          allocations: allocations
+        )
+        expect(result.size).to eq 1
+        expect(result.first).to be_a Chargify::Allocation
+        expect(result.first.payment).to be_a Chargify::Allocation::Payment
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,10 @@ RSpec.configure do |config|
   config.after(:each, :fake_resource) do
     ActiveResource::FakeResource.disable
   end
+
+  config.before(:each) do
+    Chargify.configure {}
+  end
 end
 
 def test_domain


### PR DESCRIPTION
Adds `Chargify::Allocations.bulk_create` to work with https://docs.chargify.com/api-allocations#create-multiple-allocations.

I didn't explicitly require the use of json when calling this method but I'd be open to putting a guard at the top.

I also fixed a bug in the test suite where we were relying on the side effects of calling `Chargify.configure` in `base_spec.rb`.