### PR TITLE
Force TLSv1.2

### DIFF
--- a/lib/chargify_api_ares/resources/base.rb
+++ b/lib/chargify_api_ares/resources/base.rb
@@ -1,6 +1,7 @@
 module Chargify
   class Base < ActiveResource::Base
     self.format = :xml
+    self.ssl_options = {:ssl_version => :TLSv1_2}
 
     def self.element_name
       name.split(/::/).last.underscore

--- a/spec/resources/base_spec.rb
+++ b/spec/resources/base_spec.rb
@@ -7,6 +7,10 @@ describe Chargify::Base do
     Chargify::Base.element_name.should eql('element_name')
   end
 
+  it 'uses tls v1.2' do
+    Chargify::Base.ssl_options[:ssl_version].should eql(:TLSv1_2)
+  end
+
   context 'configuration changes' do
     before do
       @original_subdomain = Chargify.subdomain


### PR DESCRIPTION
Simply forces ActiveResource to use TLSv1.2 for Chargify::Base and all sub classes.