### PR TITLE
Fix class name for Payment in allocation_spec

### DIFF
--- a/spec/resources/allocation_spec.rb
+++ b/spec/resources/allocation_spec.rb
@@ -82,9 +82,10 @@ describe Chargify::Allocation do
           subscription_id: subscription_id,
           allocations: allocations
         )
+        puts result.inspect
         expect(result.size).to eq 1
         expect(result.first).to be_a Chargify::Allocation
-        expect(result.first.payment).to be_a Chargify::Allocation::Payment
+        expect(result.first.payment).to be_a Chargify::Payment
       end
     end
   end


### PR DESCRIPTION
This test is failing on master: https://travis-ci.org/chargify/chargify_api_ares/jobs/128883049

Examining the response, this should be Chargify::Payment not Chargify::Allocation::Payment

`[#<Chargify::Allocation:0x007f944d267d28 @attributes={"component_id"=>456, "subscription_id"=>123, "quantity"=>1, "previous_quantity"=>0, "memo"=>"test", "timestamp"=>"2016-05-27 11:45:08 -0400", "proration_upgrade_scheme"=>"prorate-attempt-capture", "proration_downgrade_scheme"=>"no-prorate", "payment"=>#<Chargify::Payment:0x007f944d266e50 @attributes={"amount_in_cents"=>2000, "success"=>true, "memo"=>"Payment for: Prorated component allocation", "id"=>123}, @prefix_options={}, @persisted=false>}, @prefix_options={}, @persisted=true>]`