### PR TITLE
Add Chargify::Allocation::Payment class

### DIFF
--- a/lib/chargify_api_ares/resources/allocation.rb
+++ b/lib/chargify_api_ares/resources/allocation.rb
@@ -36,5 +36,11 @@ module Chargify
         connection.format = orig_format
       end
     end
+
+    # Needed to avoid ActiveResource using Chargify::Payment
+    # when there is a Payment inside an Allocation.
+    # This Payment is an output-only attribute of an Allocation.
+    class Payment < Base
+    end
   end
 end


### PR DESCRIPTION
This is needed so that ActiveResource will not use Chargify::Payment when there is a Payment inside an Allocation.

This Payment is an output-only attribute of an Allocation.

The Payment class should inherit from Base so that its initialize method is defined properly.

Fixes https://github.com/chargify/chargify_api_ares/issues/131