### PR TITLE
Add #find_pdf to Invoice; Allow subscription to list invoices

### DIFF
--- a/lib/chargify_api_ares/resources/invoice.rb
+++ b/lib/chargify_api_ares/resources/invoice.rb
@@ -16,5 +16,13 @@ module Chargify
     def self.unpaid
       find(:all, {:params => {:state => "unpaid"}})
     end
+
+    # Returns raw PDF data. Usage example:
+    # File.open(file_path, 'wb+'){ |f| f.write Chargify::Invoice.find_pdf(invoice.id) }
+    def self.find_pdf(scope, options = {})
+      prefix_options, query_options = split_options(options[:params])
+      path = element_path(scope, prefix_options, query_options).gsub(/\.\w+$/, ".pdf")
+      connection.get(path, headers).body
+    end
   end
 end

--- a/lib/chargify_api_ares/resources/subscription.rb
+++ b/lib/chargify_api_ares/resources/subscription.rb
@@ -123,6 +123,17 @@ module Chargify
       Statement.find(:all, :params => params)
     end
 
+    def invoices(params = {})
+      params.merge!(subscription_id: self.id)
+      Invoice.find(:all, params: params)
+    end
+
+    def invoice(id)
+      invoice = Chargify::Invoice.find(id)
+      raise ActiveResource::ResourceNotFound.new(nil) if (invoice.subscription_id != self.id)
+      invoice
+    end
+
     def transactions(params = {})
       params.merge!(:subscription_id => self.id)
       Transaction.find(:all, :params => params)

--- a/spec/resources/invoice_spec.rb
+++ b/spec/resources/invoice_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Chargify::Invoice, :fake_resource do
+
+  describe '.find_pdf' do
+    before do
+      FakeWeb.register_uri(:get, "#{test_domain}/invoices/1.pdf", body: 'fake_pdf')
+    end
+
+    it 'downloads pdf statement' do
+      pdf = Chargify::Invoice.find_pdf(1)
+      pdf.should == 'fake_pdf'
+    end
+  end
+
+end


### PR DESCRIPTION
Similar to methods already available for statements, this adds the following methods for invoices:
`Invoice.find_pdf`
`Subscription#invoices`
`Subscription#invoice`

Also added some tests for the Subscription model where none existed before - hopefully I've put these in the right place.