### PR TITLE
Allow filtering Invoices by status

### DIFF
--- a/lib/chargify_api_ares/resources/invoice.rb
+++ b/lib/chargify_api_ares/resources/invoice.rb
@@ -10,11 +10,19 @@ module Chargify
     end
 
     def self.unpaid_from_subscription(subscription_id)
-      find(:all, {:params => {:subscription_id => subscription_id, :state => "unpaid"}})
+      status_from_subscription(subscription_id, "unpaid")
+    end
+
+    def self.status_from_subscription(subscription_id, status)
+      find(:all, {:params => {:subscription_id => subscription_id, :status => status}})
     end
 
     def self.unpaid
-      find(:all, {:params => {:state => "unpaid"}})
+      find_by_status("unpaid")
+    end
+
+    def self.find_by_status(status)
+      find(:all, {:params => {:status => status}})
     end
 
     # Returns raw PDF data. Usage example:

--- a/spec/resources/invoice_spec.rb
+++ b/spec/resources/invoice_spec.rb
@@ -14,3 +14,103 @@ describe Chargify::Invoice, :fake_resource do
   end
 
 end
+
+describe Chargify::Invoice, "#unpaid_from_subscription", :fake_resource do
+  let(:invoices) do
+    [
+      {
+        :invoice => { :id => 99, :subscription_id => 1, :state => "unpaid" }
+      }
+    ]
+  end
+
+  before do
+    FakeWeb.register_uri(
+      :get,
+      "#{test_domain}/invoices.xml?subscription_id=1&status=unpaid",
+      body: invoices.to_xml(root: "invoices")
+    )
+  end
+
+  it 'sends the correct params to the Chargify Invoices API endpoint' do
+    response = Chargify::Invoice.unpaid_from_subscription(1)
+    expect(response.count).to eql(1)
+    invoice = response.first
+    expect(invoice.attributes).to eql({ "id" => 99, "subscription_id" => 1, "state" => "unpaid" })
+  end
+end
+
+describe Chargify::Invoice, "#status_from_subscription", :fake_resource do
+  let(:invoices) do
+    [
+      {
+        :invoice => { :id => 99, :subscription_id => 1, :state => "paid" }
+      }
+    ]
+  end
+
+  before do
+    FakeWeb.register_uri(
+      :get,
+      "#{test_domain}/invoices.xml?subscription_id=1&status=paid",
+      body: invoices.to_xml(root: "invoices")
+    )
+  end
+
+  it 'sends the correct params to the Chargify Invoices API endpoint' do
+    response = Chargify::Invoice.status_from_subscription(1, "paid")
+    expect(response.count).to eql(1)
+    invoice = response.first
+    expect(invoice.attributes).to eql({ "id" => 99, "subscription_id" => 1, "state" => "paid" })
+  end
+end
+
+describe Chargify::Invoice, "#unpaid", :fake_resource do
+  let(:invoices) do
+    [
+      {
+        :invoice => { :id => 99, :subscription_id => 1, :state => "unpaid" }
+      }
+    ]
+  end
+
+  before do
+    FakeWeb.register_uri(
+      :get,
+      "#{test_domain}/invoices.xml?status=unpaid",
+      body: invoices.to_xml(root: "invoices")
+    )
+  end
+
+  it 'sends the correct params to the Chargify Invoices API endpoint' do
+    response = Chargify::Invoice.unpaid
+    expect(response.count).to eql(1)
+    invoice = response.first
+    expect(invoice.attributes).to eql({ "id" => 99, "subscription_id" => 1, "state" => "unpaid" })
+  end
+end
+
+describe Chargify::Invoice, "#find_by_status", :fake_resource do
+  let(:invoices) do
+    [
+      {
+        :invoice => { :id => 99, :subscription_id => 1, :state => "partial" }
+      }
+    ]
+  end
+
+  before do
+    FakeWeb.register_uri(
+      :get,
+      "#{test_domain}/invoices.xml?status=partial",
+      body: invoices.to_xml(root: "invoices")
+    )
+  end
+
+  it 'sends the correct params to the Chargify Invoices API endpoint' do
+    response = Chargify::Invoice.find_by_status("partial")
+    expect(response.count).to eql(1)
+    invoice = response.first
+    expect(invoice.attributes).to eql({ "id" => 99, "subscription_id" => 1, "state" => "partial" })
+  end
+end


### PR DESCRIPTION
Fixes a bug where the gem was sending the wrong parameter (`state`) to the Invoices endpoint to get all unpaid invoices. The correct parameter is `status`.

Also adds a method to filter Invoices by any `status`, as well as any `subscription_id` and `status`.

Addresses https://github.com/chargify/chargify_api_ares/issues/136