### PR TITLE
Make coupon subcodes findable

### DIFF
--- a/lib/chargify_api_ares/resources/coupon.rb
+++ b/lib/chargify_api_ares/resources/coupon.rb
@@ -7,7 +7,7 @@ module Chargify
     end
 
     def self.find_by_product_family_id_and_code(product_family_id, code)
-      find(:one, :from => :lookup, :params => {:product_family_id => product_family_id, :code => code})
+      find(:one, :from => :find, :params => {:product_family_id => product_family_id, :code => code})
     end
 
     def self.validate(params = {})

--- a/spec/resources/coupon_spec.rb
+++ b/spec/resources/coupon_spec.rb
@@ -5,7 +5,7 @@ describe Chargify::Coupon, :fake_resource do
     let(:existing_coupon) { build(:coupon, :code => '20OFF') }
     
     before(:each) do
-      FakeWeb.register_uri(:get, "#{test_domain}/coupons/lookup.xml?code=#{existing_coupon.code}&product_family_id=10", :body => existing_coupon.attributes.to_xml)
+      FakeWeb.register_uri(:get, "#{test_domain}/coupons/find.xml?code=#{existing_coupon.code}&product_family_id=10", :body => existing_coupon.attributes.to_xml)
     end
     
     it "finds the correct coupon by product family and code" do


### PR DESCRIPTION
The previous code was able to find coupons by code, but there was no way to find them by their subcodes.