### PR TITLE
Add Retry method to Subscription

### DIFF
--- a/lib/chargify_api_ares/resources/subscription.rb
+++ b/lib/chargify_api_ares/resources/subscription.rb
@@ -102,6 +102,12 @@ module Chargify
       end
     end
 
+    def retry
+      process_capturing_errors do
+        put :retry
+      end
+    end
+
     def reset_balance
       process_capturing_errors do
         put :reset_balance

--- a/spec/remote/remote_spec.rb
+++ b/spec/remote/remote_spec.rb
@@ -388,6 +388,24 @@ describe "Remote" do
     end
   end
 
+  describe "retrying a payment" do
+    before(:all) do
+      @subscription = Chargify::Subscription.create(
+        :product_handle => pro_plan.handle,
+        :customer_reference => johnadoe.reference,
+        :payment_profile_attributes => good_payment_profile_attributes)
+    end
+
+    it "puts it in the active state" do
+      lambda{
+          @subscription.retry
+        }.should change{@subscription.reload.transactions.size}.by(1)
+
+        tx = most_recent_transaction(@subscription)
+        tx.transaction_type.should == 'retry'
+    end
+  end
+
   describe "adding a one time charge" do
     before(:all) do
       @subscription = Chargify::Subscription.create(


### PR DESCRIPTION
Right now subscription does not have a `retry` method for calling the RETRY option that is documented on the [API-DOCS](https://docs.chargify.com/api-subscriptions#retry). 
