### PR TITLE
Add retry method to subscription

### DIFF
--- a/examples/subscriptions.rb
+++ b/examples/subscriptions.rb
@@ -68,3 +68,6 @@ subscription.product_change('new-handle', true)
 
 # Cancel a delayed product change
 subscription.cancel_delayed_product_change
+
+# Retry a past-due subscription
+subscription.retry

--- a/lib/chargify_api_ares/resources/subscription.rb
+++ b/lib/chargify_api_ares/resources/subscription.rb
@@ -102,6 +102,12 @@ module Chargify
       end
     end
 
+    def retry
+      process_capturing_errors do
+        put :retry
+      end
+    end
+
     def reset_balance
       process_capturing_errors do
         put :reset_balance


### PR DESCRIPTION
Adds the ability to retry a past-due subscription as shown in https://reference.chargify.com/v1/subscriptions/retry-subscription

As suggested by @gotchahn in https://github.com/chargify/chargify_api_ares/pull/145

A remote test for this is problematic because there is no way to programmatically put a subscription into the past_due state.  It must go through an assessment and fail before it will transition to past_due.