### PR TITLE
Add missing Chargify::Product::PublicSignupPage

### DIFF
--- a/lib/chargify_api_ares/resources/product.rb
+++ b/lib/chargify_api_ares/resources/product.rb
@@ -21,5 +21,8 @@ module Chargify
         load_attributes_from_response(response)
       end
     end
+
+    class PublicSignupPage < Base
+    end
   end
 end


### PR DESCRIPTION
Fixes `NameError: uninitialized constant Chargify::Product::PublicSignupPage`