### PR TITLE
Update bundler version in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,4 +67,4 @@ DEPENDENCIES
   vcr
 
 BUNDLED WITH
-   1.14.6
+   1.15.4


### PR DESCRIPTION
The build on Travis is currently broken and it looks like it's related to a different version of Bundler being installed (from https://travis-ci.org/chargify/chargify_api_ares/jobs/256100770):
```
$ gem update bundler
$ bundle install --jobs=3 --retry=3 --deployment
You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated gemfiles/rails_4.1.gemfile.lock to version control.
```