### PR TITLE
Add bundle install --no-deployment to travis before_install hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 before_install:
   - gem update --system
   - gem update bundler
+  - bundle install --no-deployment
 rvm:
   - 2.1.3
   - 2.0.0


### PR DESCRIPTION
Using an SSH session on travis, found that running `bundle install --no-deployment` before the `install` section allowed the `bundle install --jobs=3 --retry=3 --deployment` to run successfully, while it is currently causing the build to error out.