### PR TITLE
Allows canceling a subscription with all supported attributes

### DIFF
--- a/examples/subscriptions.rb
+++ b/examples/subscriptions.rb
@@ -53,6 +53,12 @@ subscription.cancel
 subscription.reload
 # => #<Chargify::Subscription:0x1020ed4b0 @prefix_options={}, @attributes={"cancellation_message"=>nil, "activated_at"=>Tue Nov 17 16:00:17 UTC 2009, "expires_at"=>nil, "updated_at"=>Tue Nov 17 16:00:17 UTC 2009, "credit_card"=>#<Chargify::Subscription::CreditCard:0x10234f168 @prefix_options={}, @attributes={"card_type"=>"bogus", "expiration_year"=>2015, "masked_card_number"=>"XXXX-XXXX-XXXX-2", "first_name"=>"Michael", "expiration_month"=>1, "last_name"=>"Klett"}>, "product"=>#<Chargify::Product:0x10234f370 @prefix_options={}, @attributes={"price_in_cents"=>0, "name"=>"Chargify API Ares Test", "handle"=>"chargify-api-ares-test", "product_family"=>#<Chargify::Product::ProductFamily:0x102354708 @prefix_options={}, @attributes={"name"=>"Chargify API ARes Test", "handle"=>"chargify-api-ares-test", "id"=>79, "accounting_code"=>nil}>, "id"=>153, "accounting_code"=>nil, "interval_unit"=>"month", "interval"=>1}>, "credit_card_attributes"=>{:full_number=>"2", :expiration_year=>"2015"}, "trial_ended_at"=>nil, "id"=>331, "current_period_ends_at"=>Thu Dec 17 16:00:17 UTC 2009, "product_handle"=>"chargify-api-ares-test", "customer"=>#<Chargify::Customer:0x10234f730 @prefix_options={}, @attributes={"reference"=>"moklett", "updated_at"=>Tue Nov 17 15:51:02 UTC 2009, "id"=>331, "first_name"=>"Michael", "organization"=>"Chargify", "last_name"=>"Klett", "email"=>"moklett@example.com", "created_at"=>Tue Nov 17 15:51:02 UTC 2009}>, "trial_started_at"=>nil, "balance_in_cents"=>0, "current_period_started_at"=>Tue Nov 17 16:00:17 UTC 2009, "state"=>"canceled", "created_at"=>Tue Nov 17 16:00:17 UTC 2009, "customer_reference"=>"moklett"}>
 
+# Cancel a subscription with key/value options (Omitted options remain nil)
+subscription.cancel(
+  :cancellation_message => "Some cancellation message",
+  :reason_code => "Some reason code"
+)
+
 # Schedule a delayed cancellation
 subscription.delayed_cancel
 subscription.delayed_cancel(true)

--- a/lib/chargify_api_ares/resources/subscription.rb
+++ b/lib/chargify_api_ares/resources/subscription.rb
@@ -21,12 +21,19 @@ module Chargify
       super
     end
 
-    def cancel(cancellation_message = nil)
-      if cancellation_message.nil?
+    def cancel(params = {})
+      if params.blank?
         destroy
       else
         #Destroy does not support body, must work around it to send verb DELETE
-        self.connection.post(element_path, {:cancellation_message => cancellation_message}.to_xml(:root => :subscription), self.class.headers.merge({'X-Http-Method-Override' => 'DELETE'}))
+        self.connection.post(
+          element_path,
+          {
+            cancellation_message: params[:cancellation_message] || nil,
+            reason_code: params[:reason_code] || nil
+          }.to_xml(:root => :subscription),
+          self.class.headers.merge({'X-Http-Method-Override' => 'DELETE'})
+        )
       end
     end
 

--- a/spec/remote/remote_spec.rb
+++ b/spec/remote/remote_spec.rb
@@ -330,6 +330,30 @@ describe "Remote" do
       @subscription.cancel
       Chargify::Subscription.find(@subscription.id).state.should == 'canceled'
     end
+
+    it "does not set optional attributes" do
+      @subscription.cancel
+      @subscription.reload.cancellation_message.should be_nil
+      @subscription.reload.reason_code.should be_nil
+    end
+
+    it "only sets optional cancellation_message attribute" do
+      @subscription.cancel(cancellation_message: "This is a cancellation message.")
+      @subscription.reload.cancellation_message.should == "This is a cancellation message."
+      @subscription.reload.reason_code.should be_nil
+    end
+
+    it "only sets optional reason_code attribute" do
+      @subscription.cancel(reason_code: "This is a reason code.")
+      @subscription.reload.cancellation_message.should be_nil
+      @subscription.reload.reason_code.should == "This is a reason code."
+    end
+
+    it "sets multiple optional attributes" do
+      @subscription.cancel(cancellation_message: "This is a cancellation message.", reason_code: "This is a reason code.")
+      @subscription.reload.cancellation_message.should == "This is a cancellation message."
+      @subscription.reload.reason_code.should == "This is a reason code."
+    end
   end
 
   describe "scheduling a subscription cancellation" do


### PR DESCRIPTION
Supported Attributes:
 - `cancellation_message`
 - ~`cancellation_method`~
 - `reason_code`

API reference
https://reference.chargify.com/v1/subscriptions-cancellations#cancel-subscription-2

Closes #160 