### PR TITLE
Changed Subscription#remove_coupon to use coupon_code instead of code…

### DIFF
--- a/lib/chargify_api_ares/resources/subscription.rb
+++ b/lib/chargify_api_ares/resources/subscription.rb
@@ -170,7 +170,7 @@ module Chargify
         if code.nil?
           delete :remove_coupon
         else
-          delete :remove_coupon, :code => code
+          delete :remove_coupon, :coupon_code => code
         end
       end
     end


### PR DESCRIPTION
… as the query parameter

https://reference.chargify.com/v1/subscriptions-coupons/remove-the-coupon-from-the-subscription